### PR TITLE
update of metaspan PR for encointer boot node

### DIFF
--- a/docs/4-auditors/2-progress.md
+++ b/docs/4-auditors/2-progress.md
@@ -100,7 +100,7 @@ And the following PRs belong to the Encointer repository:
 | Member      | Encointer (**Kusama**)                                           |
 | ----------- | ---------------------------------------------------------------- |
 | stake.plus  | [162](https://github.com/encointer/encointer-parachain/pull/162) |
-| metaspan    | [163](https://github.com/encointer/encointer-parachain/pull/163) |
+| metaspan    | [196](https://github.com/encointer/encointer-parachain/pull/196) |
 | turboflakes | [164](https://github.com/encointer/encointer-parachain/pull/164) |
 | gatotech    | [165](https://github.com/encointer/encointer-parachain/pull/165) |
 | amforc      | [166](https://github.com/encointer/encointer-parachain/pull/166) |


### PR DESCRIPTION
The previous PR was stuck behind a merge that was too complex for the github web ui.
It is just easier to recreate the PR 